### PR TITLE
feat: Create BBC-style interview example page

### DIFF
--- a/articles/bbc_interview_example.html
+++ b/articles/bbc_interview_example.html
@@ -1,0 +1,80 @@
+<!DOCTYPE html>
+<html xmlns="http://www.w3.org/1999/xhtml" lang="en" xml:lang="en">
+
+<head>
+    <meta charset="utf-8" />
+    <title>BBC Style Interview Example | gart blog</title>
+    <link rel="stylesheet" href="../reset.css" />
+    <link rel="stylesheet" href="../index.css" />
+    <link rel='icon' type='favicon/icon.ico' href='../images/favicon/icon.ico'>
+</head>
+
+<body>
+    <table class="header">
+        <tr>
+            <td colspan="2" rowspan="2" class="width-auto">
+                <h1 class="title">gart blog</h1>
+                <span class="subtitle">who gave gart a website</span>
+            </td>
+        </tr>
+        <tr>
+            <th>updated</th>
+            <td class="width-min"><time style="white-space: pre;">YYYY-MM-DD</time></td> {/* TODO: Update date */}
+        </tr>
+        <tr>
+            <th class="width-min">author</th>
+            <td class="width-auto"><cite>gart</cite></td>
+        </tr>
+        <tr>
+            <th>back to</th>
+            <td class="width-min"><a href="../index.html">main page..</a></td>
+        </tr>
+    </table>
+
+    <main>
+        <h2>Exclusive Interview: A Deep Dive into [Topic]</h2>
+
+        <p><em>In this special feature, we sit down with [Interviewee Name], a leading expert in [Field/Area of Expertise], to discuss the pressing issues surrounding [Topic]. This conversation sheds light on [briefly mention key themes].</em></p>
+
+        <div class="interview-container">
+            <div class="interview-question">
+                <strong>Interviewer:</strong> Welcome, [Interviewee Name]. Thank you for joining us. Could you start by telling us a bit about [Initial Question Context]?
+            </div>
+            <div class="interview-answer">
+                <strong>[Interviewee Name]:</strong> Thank you for having me. Regarding [Initial Question Context], it's a complex situation. My perspective is that [start of answer]...
+            </div>
+
+            <div class="interview-question">
+                <strong>Interviewer:</strong> That's insightful. Following up on that, what are your thoughts on [Follow-up Question Detail]?
+            </div>
+            <div class="interview-answer">
+                <strong>[Interviewee Name]:</strong> That's an excellent question. When we consider [Follow-up Question Detail], we need to look at several factors. Firstly, [Factor 1]. Secondly, [Factor 2].
+            </div>
+
+            <div class="interview-question">
+                <strong>Interviewer:</strong> Many of our readers are concerned about [Specific Concern]. How would you address that?
+            </div>
+            <div class="interview-answer">
+                <strong>[Interviewee Name]:</strong> I understand that concern. It's true that [Specific Concern] is a significant point. However, it's also important to remember that [Counterpoint or Reassurance]. We are actively working on [Solution/Mitigation, if applicable].
+            </div>
+
+            <div class="interview-question">
+                <strong>Interviewer:</strong> Looking ahead, what do you foresee as the major challenges or developments in [Field/Area of Expertise] in the next five years?
+            </div>
+            <div class="interview-answer">
+                <strong>[Interviewee Name]:</strong> The landscape is constantly evolving. I anticipate that [Challenge/Development 1] will be a major focus. Additionally, we'll likely see more of [Challenge/Development 2]. It's crucial that we prepare for these shifts by [Action/Strategy].
+            </div>
+
+            <div class="interview-question">
+                <strong>Interviewer:</strong> Finally, do you have any message for our audience regarding [Topic]?
+            </div>
+            <div class="interview-answer">
+                <strong>[Interviewee Name]:</strong> Absolutely. I would encourage everyone to stay informed and engaged. Understanding [Topic] is vital because [Reason]. And if there's one takeaway, it's that [Final Message].
+            </div>
+        </div>
+
+        <p><em>This interview has been edited for length and clarity.</em></p>
+    </main>
+
+</body>
+</html>

--- a/index.css
+++ b/index.css
@@ -455,3 +455,28 @@ label input {
 .debug-toggle-label {
   text-align: right;
 }
+
+/* Styles for interview format */
+.interview-container {
+    margin-top: var(--line-height);
+}
+
+.interview-question, .interview-answer {
+    margin-bottom: var(--line-height);
+}
+
+.interview-question strong,
+.interview-answer strong { /* For "Interviewer:" and "Interviewee Name:" labels */
+    display: block;
+    margin-bottom: calc(var(--line-height) / 2);
+    font-weight: var(--font-weight-bold); /* Ensure labels are bold */
+}
+
+/* Additional styling to differentiate Q and A a bit more, similar to galtinterview.html */
+.interview-question {
+    /* Optional: Add specific styling for questions if needed */
+}
+
+.interview-answer {
+    padding-left: 2ch; /* Indent answers slightly, similar to a blockquote or offset text */
+}


### PR DESCRIPTION
Adds a new HTML page `articles/bbc_interview_example.html` to serve as a template for news interview articles. The page structure is based on existing articles and includes placeholder content.

Relevant CSS styles for formatting the interview Q&A have been added to `index.css` to maintain consistency and leverage existing site styling.